### PR TITLE
Feature/python 39 compatible

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -46,10 +46,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install with plain pip
       run: pip install ./
     - name: Do a dry run

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -70,3 +70,21 @@ jobs:
           push: false
           load: ${{ github.event_name == 'pull_request' }}
           context: .
+
+  docker_test_build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: checkout files 
+        uses: actions/checkout@v2
+      - name: build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile-test
+          push: false
+          load: ${{ github.event_name == 'pull_request' }}
+          context: .
+
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.12-buster
+FROM python:3.9.12-buster
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.8-buster
+FROM python:3.9.7-buster
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.12-buster
+FROM python:3.9.8-buster
 
 EXPOSE 8000
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM python:3.8.12-buster
+FROM python:3.9.7-buster
 
 EXPOSE 8000
 ARG secret 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,3 +1,5 @@
+# Tests for Python 3.9 compatibilty
+
 FROM python:3.9.7-buster
 
 EXPOSE 8000
@@ -7,19 +9,49 @@ ENV OSD2F_SECRET=$secret
 ENV OSD2F_MODE="Development"
 ENV OSD2F_DB_URL="sqlite://:memory:"
 
-# make code available
+## make code available
 COPY ./ ./osd2f
 
-# add build-secret to hypercorn config
+## add build-secret to hypercorn config
 
 WORKDIR /osd2f
 
-# setup dependencies
+## setup dependencies
 RUN pip install ./ 
 RUN pip install -r requirements.txt
 RUN pip install -r requirements_dev.txt
 
-# run tests
+## run tests
+RUN flake8 ./
+RUN mypy ./osd2f/ --ignore-missing-imports
+RUN pytest ./
+
+RUN osd2f --dry-run
+
+# Tests for Python 3.8 compatibility
+
+FROM python:3.8.12-buster
+
+EXPOSE 8000
+ARG secret 
+
+ENV OSD2F_SECRET=$secret
+ENV OSD2F_MODE="Development"
+ENV OSD2F_DB_URL="sqlite://:memory:"
+
+## make code available
+COPY ./ ./osd2f
+
+## add build-secret to hypercorn config
+
+WORKDIR /osd2f
+
+## setup dependencies
+RUN pip install ./ 
+RUN pip install -r requirements.txt
+RUN pip install -r requirements_dev.txt
+
+## run tests
 RUN flake8 ./
 RUN mypy ./osd2f/ --ignore-missing-imports
 RUN pytest ./

--- a/docs/deploying_to_azure.md
+++ b/docs/deploying_to_azure.md
@@ -11,7 +11,8 @@ This documentation is intended to demonstrate how to set up OSD2F as an Azure we
 ```bash
 az login
 az account set --subscription <subscription-to-publish-to>
-export WEBAPPNAME="osd2f-test"
+export AZURE_RESOURCE_GROUP=<your-resource-group>
+export WEBAPPNAME="osd2f-test" # must be globally unique, e.g. unused on Azure
 ```
 
 Doublecheck with:
@@ -24,16 +25,20 @@ az account show
 Using webapp up will setup the webapp, the appservice and the plan required. The app won't work before we also apply the other commands. Make sure to be inside the OSD2F folder (locally) when running this command.
 
 ```bash
+# python 3.9 is in early access on Azure (2021-11-05),
+# you can select it in the Settings > Configuration 
+# panel of the App Service under `Minor version`
 az webapp up  \
     --runtime 'python|3.8' \
     --location "West Europe" \
     --sku F1 \
+    --verbose \
     --name $WEBAPPNAME
 ```
 
 Minor addition for security:
 ```bash
-az webapp identity assign --name $WEBAPPNAME 
+az webapp identity assign --resource-group $AZURE_RESOURCE_GROUP --name $WEBAPPNAME 
 ```
 
 # setting up config with in-memory db
@@ -42,6 +47,7 @@ az webapp identity assign --name $WEBAPPNAME
 
 ```bash
 az webapp config appsettings set --name  $WEBAPPNAME\
+    --resource-group $AZURE_RESOURCE_GROUP \
     --settings \
         OSD2F_SECRET=$RANDOM$RANDOM$RANDOM$RANDOM \
         OSD2F_DB_URL="sqlite://:memory:"  \
@@ -63,6 +69,8 @@ set the custom startup command. We use the hypercorn ASGI server middleware for 
 
 ```bash
 az webapp config set \
+    --resource-group $AZURE_RESOURCE_GROUP \
+    --name $WEBAPPNAME \
     --startup-file "python -m hypercorn osd2f.__main__:app -b 0.0.0.0"
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ The intended use of this framework is to provide a participant facing data submi
 You can install this Python Package for local development purposes. To do 
 so, we *strongly* advice using a virtual environment context. 
 
-In addition, please note that OSD2F was written for Python `3.8`. Using
+In addition, please note that OSD2F was written for Python `3.9`. Using
 a virtual environment should make it easy to install this version without impacting your other Python projects.
 
 
@@ -35,7 +35,7 @@ a virtual environment should make it easy to install this version without impact
 ##### Example using the popular [anaconda distribution of python](https://www.anaconda.com/)
 
 ```bash 
-conda create -n osd2f python=3.8 # only required once
+conda create -n osd2f python=3.9 # only required once
 conda activate osd2f # run at the start of each osd2f development session
 ```
 ----

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import find_packages, setup
 
 setup(
     name="OSD2F",
-    python_requires="<3.9>3.8",
-    version="0.1.0",
+    python_requires=">3.8",
+    version="0.1.1",
     description="Open Source Data Donation Framework",
     author="Bob van de Velde",
     author_email="osd2f@bob-as-a-service.com",
-    license="TODO",
+    license=open("LICENCE").read(),
     url="https://github.com/uvacw/osd2f",
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="Open Source Data Donation Framework",
     author="Bob van de Velde",
     author_email="osd2f@bob-as-a-service.com",
-    license=open("LICENCE").read(),
+    license=open("LICENSE").read(),
     url="https://github.com/uvacw/osd2f",
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
# Use Python 3.9

## Closes #81 
____
OSD2F was written and tested for Python 3.8, primarily to support the target Azure Webapp deployment context. This update bumps the version to 3.9 as that is now available in early-access.

These changes do not drop support for Python 3.8 and everything is still 3.8 compatible as of now. We test whether both are working in the `Dockerfile-test` to guarantee backward compatibility. 

Note that the Azure Webapp environment does not seem to allow setting up an App Service with Python 3.9 via the CLI tool (most likely because it's still in early access). A comment in the azure deployment documentation tells you how to change this through the web interface. 

## Assumptions
* Python 3.9 should now be the preferred runtime environment
* Python 3.8 support should not be dropped


## Usage / Minimal Example

Build the `Dockerfile-test` to be assured both Python runtimes are supported: 
```bash
docker build -f Dockerfile-test . 
```

Follow the updated [deploying to azure](https://github.com/uvacw/osd2f/blob/feature/python_39_compatible/docs/deploying_to_azure.md) documentation to check whether webapps works.

## Checklist
- [X] Added tests if appropriate (and it should always be)
- [X] Created new issues when required
