### PR TITLE
Bugfix/update dependencies black for Python 3.9.9 compatibility

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,6 +1,6 @@
 # Tests for Python 3.9 compatibilty
 
-FROM python:3.9.7-buster
+FROM python:3.9.9-buster
 
 EXPOSE 8000
 ARG secret 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==21.11b1
 Faker==8.1.3
 flake8==3.8.4
 flake8-black==0.2.1


### PR DESCRIPTION
# Updated black for Python 3.9.9 compatibility

## Closes #83 
____
* black for Python 3.9.9 compatibility

## Assumptions
github now uses python 3.9.9 for python 3.9 actions

## Usage / Minimal Example

```bash
docker build -f Dockerfile-test . -t osd2f-test
```
Should run succesfully on this branch, but not on main. 

## Checklist
- [X] Added tests if appropriate (and it should always be)
- [X] Created new issues when required
