### PR TITLE
added blanket 'link in new tab' functionality for upload page

### DIFF
--- a/osd2f/server.py
+++ b/osd2f/server.py
@@ -100,6 +100,7 @@ async def upload():
             content_settings=content_settings,
             upload_settings=upload_settings,
             sid=request.args.get("sid", "test"),
+            all_links_new_tab=True,
         )
     # for data submissions posted by the interface
     elif request.method == "POST":

--- a/osd2f/templates/blocks/head.html.jinja
+++ b/osd2f/templates/blocks/head.html.jinja
@@ -7,5 +7,8 @@
 
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-
+    
+    {%  if all_links_new_tab   %}
+        <base target="_blank">
+    {% endif %}
 </head>


### PR DESCRIPTION
# Avoid loss of SID through new tabs

## Closes #91 ?
____
To avoid setting cookies, we only maintain the `sid` submission identifier on the upload page. When users visit links to other sites, this `sid` is lost. 

By setting all links to open in a new tab on the upload page, the `sid` of the opened page is maintained. 

## Assumptions
* The `sid` is strictly necessary for processing *only* on the `upload` page. To conform to the ePrivacy directive, we avoid any persistence and thus the need to provide an additional interface 'hurdle' to users in the form of a 'cookie' consent bar by not using cookies or storage. 
* Opening new tabs on the upload page is more convenient to users than a cookie consent module

## Usage / Minimal Example

Before:
* `sid` is lost after clicking a link

After:
* `sid` is maintained because links are opened in new tabs

## Checklist
- [ ] Added tests if appropriate (and it should always be)
- [ ] Created new issues when required
