### PR TITLE
Security/pyjwt

### DIFF
--- a/osd2f/database/__init__.py
+++ b/osd2f/database/__init__.py
@@ -1,4 +1,5 @@
 from tortoise import Tortoise
+from tortoise.contrib.quart import register_tortoise
 
 from .configuration import *  # noqa
 from .logs import *  # noqa
@@ -12,5 +13,6 @@ async def initialize_database(db_url: str):
 
 
 async def stop_database():
+    await asyncio.sleep(0.1) # to avoid start/stop race-conditions during tests
     await Tortoise.close_connections()
     stop_logworker()  # noqa

--- a/osd2f/database/__init__.py
+++ b/osd2f/database/__init__.py
@@ -1,5 +1,6 @@
+import asyncio
+
 from tortoise import Tortoise
-from tortoise.contrib.quart import register_tortoise
 
 from .configuration import *  # noqa
 from .logs import *  # noqa
@@ -13,6 +14,6 @@ async def initialize_database(db_url: str):
 
 
 async def stop_database():
-    await asyncio.sleep(0.1) # to avoid start/stop race-conditions during tests
+    await asyncio.sleep(0.1)  # to avoid start/stop race-conditions during tests
     await Tortoise.close_connections()
     stop_logworker()  # noqa

--- a/osd2f/database/logs.py
+++ b/osd2f/database/logs.py
@@ -53,7 +53,7 @@ def start_logworker():
 
 
 def stop_logworker():
-    clientLogQueue.put("STOP")
+    clientLogQueue.put("STOP", block=True)
     time.sleep(0.2)
 
 

--- a/osd2f/security/entry_encryption/secure_entry_singleton.py
+++ b/osd2f/security/entry_encryption/secure_entry_singleton.py
@@ -52,7 +52,7 @@ class SecureEntry:
     @staticmethod
     def __create_key(password: bytes) -> bytes:
         random.seed(len(password))
-        salt = bytes(random.randint(0, 10 ** 6))
+        salt = bytes(random.randint(0, 10**6))
         kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,8 +93,10 @@ pycryptodomex==3.14.1
     # via pyzipper
 pydantic[email]==1.9.0
     # via OSD2F (setup.py)
-pyjwt[crypto]==2.3.0
-    # via msal
+pyjwt[crypto]==2.4.0
+    # via
+    #   OSD2F (setup.py)
+    #   msal
 pypika-tortoise==0.1.4
     # via tortoise-orm
 pytz==2022.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
-black==21.11b1
+black==22.3.0
 Faker==8.1.3
-flake8==3.8.4
-flake8-black==0.2.1
+flake8==4.0.1
+flake8-black==0.3.3
 flake8-import-order==0.18.1
 locust==1.5.3
 mypy==0.790

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "pyyaml",
         "pydantic",
         "pydantic[email]",
+        "pyjwt>=2.4.0",  # dependency of MSAL, insecure < 2.4.0
         "pyzipper",
         "quart",
         "tortoise-orm",

--- a/tests/db_interaction_test.py
+++ b/tests/db_interaction_test.py
@@ -141,7 +141,7 @@ class LogInsertTest(AsyncTestCase):
             r = c.execute("SELECT * FROM osd2f_logs").fetchall()
             if len(r) == 4:
                 break
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(0.01)
 
         assert r, ValueError("No(t all) records returned")
 

--- a/tests/db_interaction_test.py
+++ b/tests/db_interaction_test.py
@@ -141,7 +141,7 @@ class LogInsertTest(AsyncTestCase):
             r = c.execute("SELECT * FROM osd2f_logs").fetchall()
             if len(r) == 4:
                 break
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0.05)
 
         assert r, ValueError("No(t all) records returned")
 


### PR DESCRIPTION
# Resolve pyjwt vulnerability
## Closes [Dependabot alert](https://github.com/uvacw/osd2f/security/dependabot/4)
____
There is a [security vulnerability in `pyjwt` < 2.4.0](https://github.com/uvacw/osd2f/security/dependabot/4), an indirect dependency through `msal`. The maintainers of `msal` do claim [this CVE does not impact users of `msal`](https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/473). Still, we consider it prudent to update `pyjwt` to a patched version by including it in separately in our dependencies. 

In addition, a minor tweak to logworker timings now consistently finishes the tests. 

## Assumptions
* `msal` can support `pyjwt` 2.4.0

## Usage / Minimal Example

There are no functional changes to test. 

## Checklist
- [X] Added tests if appropriate (and it should always be)
- [X] Created new issues when required
